### PR TITLE
Fix webpack and CI configuration

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -33,8 +33,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "us-east-1"
         
-      -  run: aws cloudfront create-invalidation --distribution-id ${{secrets.AWS_DISTRIBUTION_ID  }} --paths "/container/latest/index.html"
-         env:
+      - run: aws cloudfront create-invalidation --distribution-id ${{secrets.AWS_DISTRIBUTION_ID}} --paths "/container/latest/index.html"
+        env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "us-east-1"

--- a/.github/workflows/marketing.yml
+++ b/.github/workflows/marketing.yml
@@ -31,8 +31,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "us-east-1"
          
-      -  run: aws cloudfront create-invalidation --distribution-id ${{secrets.AWS_DISTRIBUTION_ID  }} --paths "/marketing/latest/remoteEntry.js"
-         env:
+      - run: aws cloudfront create-invalidation --distribution-id ${{secrets.AWS_DISTRIBUTION_ID}} --paths "/marketing/latest/remoteEntry.js"
+        env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "us-east-1"

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -2,7 +2,7 @@
   "name": "container",
   "version": "1.0.0",
   "scripts": {
-    "start": "webpack server --config config/webpack.dev.js",
+    "start": "webpack serve --config config/webpack.dev.js",
     "build": "webpack --config config/webpack.prod.js"
   },
   "dependencies": {

--- a/packages/marketing/config/webpack.prod.js
+++ b/packages/marketing/config/webpack.prod.js
@@ -2,8 +2,6 @@ const { merge } = require("webpack-merge");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
 const packageJson = require("../package.json");
 const commonConfig = require("./webpack.common");
-const { plugins } = require("../../container/config/webpack.common");
-
 const prodConfig = {
   mode: "production",
   output: {


### PR DESCRIPTION
## Summary
- remove stray import from marketing production webpack config
- correct container dev server script to use `webpack serve`
- normalize CloudFront invalidation steps in container and marketing workflows

## Testing
- `npm test` *(container; fails: Missing script "test")*
- `PRODUCTION_DOMAIN=http://example.com npm run build` *(container)*
- `npm test` *(marketing; fails: Missing script "test")*
- `npm run build` *(marketing)*

------
https://chatgpt.com/codex/tasks/task_e_689e2c246f5883338a37bead0de2a74d